### PR TITLE
Ensure prometheus_storage_path is created with correct rights

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,6 +10,7 @@
     - "{{ prometheus_conf_dir }}/alerts"
     - "{{ prometheus_conf_dir }}/rules"
     - "{{ prometheus_conf_dir }}/targets"
+    - "{{ prometheus_storage_path }}"
   loop_control:
     loop_var: dirname
 


### PR DESCRIPTION
if `prometheus_storage_path` is customized, the directory is not created and correct rights are not set which prevent prometheus to start