### PR TITLE
CHANGE(prometheus): Properly track service labels

### DIFF
--- a/templates/blackbox.yml.j2
+++ b/templates/blackbox.yml.j2
@@ -8,36 +8,50 @@
     - {{ hostname }},{{ tmp_cached_admin_ip }}=>{{ node_ip }}
     {% endfor %}
 
+{% for svc in prometheus_tcpcheck_services %}
 - labels:
     module: tcpcheck
+    service: "{{ svc }}"
   targets:
     {% for hostname, data in tmp_cached_inventory.iteritems() %}
         {% set hloop = loop %}
-        {% for service, instances in data.namespaces[tmp_cached_namespace].services.iteritems() if service in prometheus_tcpcheck_services %}
+        {% for service, instances in data.namespaces[tmp_cached_namespace].services.iteritems() if service == svc %}
             {% set src_ip = tmp_cached_node_data_ip[tmp_cached_node_data_ip.keys()[0 if hloop.last else hloop.index]] %}
             {% for conf in instances %}
-    - {{service}},{{ hostname }},{{ src_ip }}=>{{ conf.ip }}:{{ conf.port }}
+    - {{ hostname }},{{ src_ip }}=>{{ conf.ip }}:{{ conf.port }}
             {% endfor %}
         {% endfor %}
     {% endfor %}
+{% endfor %}
 
 - labels:
+    module: blackbox
+  targets:
+    - {{ prometheus_admin_host }},{{ tmp_cached_admin_ip }}=>{{ tmp_cached_admin_ip }}:{{ prometheus_blackbox_port }}
+    {% for hostname, data in tmp_cached_inventory.iteritems() %}
+    - {{ hostname }},{{ tmp_cached_node_data_ip[hostname] }}=>{{ tmp_cached_node_data_ip[hostname] }}:{{ prometheus_blackbox_port }}
+    {% endfor %}
+
+{% for svc in prometheus_oioping_services %}
+- labels:
     module: oioping
+    service: "{{ svc }}"
   targets:
     {% for hostname, data in tmp_cached_inventory.iteritems() %}
         {% set hloop = loop %}
-        {% for service, instances in data.namespaces[tmp_cached_namespace].services.iteritems() if service in prometheus_oioping_services %}
+        {% for service, instances in data.namespaces[tmp_cached_namespace].services.iteritems() if service == svc %}
             {% set src_ip = tmp_cached_node_data_ip[tmp_cached_node_data_ip.keys()[0 if hloop.last else hloop.index]] %}
             {% for conf in instances %}
-    - {{service}},{{ hostname }},{{ src_ip }}=>{{ conf.ip }}:{{ conf.port }}
+    - {{ hostname }},{{ src_ip }}=>{{ conf.ip }}:{{ conf.port }}
             {% endfor %}
         {% endfor %}
     {% endfor %}
-
+{% endfor %}
 
 {% for module in prometheus_monitored_services %}
 - labels:
-    module: "{{module}}"
+    module: "{{ module }}"
+    service: "{{ module }}"
   targets:
     {% for hostname, data in tmp_cached_inventory.iteritems() %}
         {% set hloop = loop %}

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -68,25 +68,6 @@ scrape_configs:
     - source_labels: [module]
       target_label: job
 
-    # ALL: Register job as service
-    - source_labels: [module]
-      regex: .*
-      target_label: service
-
-    # TCPCheck, OIOPING: Register the service type in `service`
-    # in: tcpcheck;oioproxy,worker-4,10.240.0.23=>10.240.0.24:6006
-    # out: oioproxy
-    - source_labels: [module, __address__]
-      regex: (?:tcpcheck|oioping);([^,]+),.+
-      target_label: service
-
-    # TCPCheck: Strip the service type in the address
-    # in: tcpcheck;oioproxy,worker-4,10.240.0.23=>10.240.0.24:6006
-    # out: worker-4,10.240.0.23=>10.240.0.24:6006
-    - source_labels: [module, __address__]
-      regex: (?:tcpcheck|oioping);[^,]+,(.+)
-      target_label: __address__
-
     # Register the host in `host`
     # in: worker-4,10.240.0.23=>10.240.0.24:6006
     # out: worker-4
@@ -105,7 +86,7 @@ scrape_configs:
     # in: beanstalkd;10.240.0.23=>10.240.0.24:6014
     # out: 10.240.0.24:6014
     - source_labels: [module, __address__]
-      regex: (?:beanstalkd|icmpcheck|redis|redissentinel|tcpcheck|zookeeper|oioping);[^=]+=>(.+)
+      regex: (?:beanstalkd|icmpcheck|redis|redissentinel|tcpcheck|zookeeper|oioping|blackbox);[^=]+=>(.+)
       target_label: __param_target
 
     # in: rdir;10.240.0.23=>10.240.0.24:6301


### PR DESCRIPTION
 ##### SUMMARY

Since the refactoring of checks to use oioping, we couldn't track
service types properly. With this change, all tcpchecks, oioping and
openio service module checks have a service type label.

This change also adds rules to selftest blackbox instances.

 ##### ISSUE TYPE
- Feature Pull Request

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION