### PR TITLE
Use actual hostnames for blackbox configuration

### DIFF
--- a/tasks/healthchecks.yml
+++ b/tasks/healthchecks.yml
@@ -24,7 +24,7 @@
 
 - name: Cache hostnames
   set_fact:
-    tmp_cached_hostnames: "{{ tmp_cached_hostnames | combine({item: hostvars[item]['ansible_hostname']}) }}"
+    tmp_cached_hostnames: "{{ tmp_cached_hostnames | combine({item: hostvars[item]['ansible_nodename']}) }}"
   with_items: "{{ prometheus_monitored_hosts }}"
   when: inventory_hostname == prometheus_admin_host
 
@@ -48,7 +48,7 @@
 - name: "Fetch inventories"
   fetch:
     src: "/etc/oio/sds/{{ hostvars[inventory_hostname]['namespace'] }}/inventory.yml"
-    dest: "../inventories/{{ hostvars[inventory_hostname]['namespace'] }}/{{ ansible_hostname }}.yml"
+    dest: "../inventories/{{ hostvars[inventory_hostname]['namespace'] }}/{{ ansible_nodename }}.yml"
     flat: true
   changed_when: false
   when: inventory_hostname in prometheus_monitored_hosts


### PR DESCRIPTION
Blackbox checks were using hostname value from `ansible_hostname`, which was causing some invalid values:
`sds-1` (value in blackbox checks) vs `sds-1.novalocal` (value in prometheus)
Use `ansible_nodename` to get full hostname.