### PR TITLE
FEATURE(prometheus): Add oiofs connector healthcheck

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,4 +38,7 @@ prometheus_blackbox_node_data_iface: eth0
 prometheus_blackbox_node_admin_iface: eth0
 prometheus_blackbox_admin_iface: eth0
 prometheus_monitored_hosts: []
+
+prometheus_oiofs_monitor: false
+prometheus_oiofs_endpoints: []
 ...

--- a/templates/blackbox.yml.j2
+++ b/templates/blackbox.yml.j2
@@ -72,3 +72,14 @@
         {% endif %}
     {% endfor %}
 {% endfor %}
+
+
+{% if prometheus_oiofs_monitor | default(false) %}
+- labels:
+    module: "oiofs"
+    service: "oiofs"
+  targets:
+    {% for endpoint in prometheus_oiofs_endpoints if endpoint.enabled | default(false) %}
+      - {{ endpoint.id }},{{ tmp_cached_admin_ip }}=>{{ endpoint.addr }}
+    {% endfor %}
+{% endif %}

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -118,6 +118,13 @@ scrape_configs:
       replacement: http://${1}/info
       target_label: __param_target
 
+    # in: oiofs;10.240.0.23=>10.240.0.24:6999
+    # out: http://10.240.0.24:6999/stats
+    - source_labels: [module, __address__]
+      regex: oiofs;[^=]+=>(.+)
+      replacement: http://${1}/stats
+      target_label: __param_target
+
     # Remove the targets part of the address
     # in: 10.240.0.23=>10.240.0.24:6201
     # out: 10.240.0.23:6115


### PR DESCRIPTION
 ##### SUMMARY
This allows the oiofs connector instances to be healthchecked by the
admin machine.

Defaults format specified via prometheus_oiofs_monitor and prometheus_oiofs_endpoints
should be the same as the one provided in netdata role

 ##### ISSUE TYPE
- Feature Pull Request

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION