### PR TITLE
FEATURE(prometheus): Allow Prometheus to be started at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This role deploys a Prometheus setup, specifically tuned for the monitoring of O
 | Variable                     | Description                                | Type    |
 | ---------------------------- | ------------------------------------------ | ------- |
 | prometheus_admin_host        | Hostname of admin machine                  | string  |
+| prometheus_systemd_enabled   | Enable service at boot                     | boolean |
 | prometheus_systemd_limits    | Limits to setup in systemd unit file       | dict    |
 | prometheus_listen_ip         | IP address on which Prometheus will listen | string  |
 | prometheus_listen_port       | Port on which Prometheus will listen       | integer |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ prometheus_version: 2.2.1
 prometheus_storage_path: /var/lib/prometheus/data
 prometheus_conf_dir: /etc/prometheus
 prometheus_provision_only: false
+prometheus_systemd_enabled: true
 prometheus_systemd_limits:
   MemoryAccounting: 'true'
   MemoryLimit: '24G'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
       systemd:
         state: "{{ 'started' if prometheus_provision_only else 'restarted' }}"
         daemon_reload: true
-        enabled: true
+        enabled: "{{ prometheus_systemd_enabled }}"
         name: "prometheus"
 
     - name: "Prometheus: wait for service to be up"


### PR DESCRIPTION
 ##### SUMMARY
Add a variable to control Prometheus state at boot.
By default, Prometheus is enabled at boot.

 ##### IMPACT
N/A