### PR TITLE
BUGFIX/MINOR(prometheus): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -14,6 +14,7 @@
   loop_control:
     loop_var: dirname
   register: _prometheus_dirs
+  tags: configure
 
 - name: "Setup recording rules"
   template:
@@ -23,12 +24,14 @@
   with_items:
     - "{{ prometheus_aggregation_rules }}"
   register: _prometheus_aggr
+  tags: configure
 
 - name: "Setup alerting rules"
   copy:
     content: "{{ lookup('file', 'alert_rules.yml') | format_alerts }}"
     dest: "/etc/prometheus/alerts/default.rules"
   register: _prometheus_alerts
+  tags: configure
 
 - name: "Setup prometheus config yml"
   template:
@@ -38,6 +41,7 @@
     group: "{{ prometheus_group }}"
     validate: "{{ promtool_check_config_cmd }} %s"
   register: _prometheus_conf
+  tags: configure
 
 - name: "Create prometheus run options"
   set_fact:
@@ -49,6 +53,7 @@
       web.listen-address: "{{ prometheus_bind_address }}:{{ prometheus_bind_port }}"
       web.external-url: "http://{{ prometheus_bind_address }}:{{ prometheus_bind_port }}"
       log.level: "{{ prometheus_loglevel }}"
+  tags: configure
 
 - name: Save Prometheus run options
   template:
@@ -57,4 +62,5 @@
     owner: "{{ prometheus_user }}"
     group: "{{ prometheus_group }}"
   register: _prometheus_defaults
+  tags: configure
 ...

--- a/tasks/healthchecks.yml
+++ b/tasks/healthchecks.yml
@@ -8,6 +8,7 @@
     tmp_cached_hostnames: {}
     tmp_cached_oiofs_endpoints: {}
     tmp_cached_namespace: ""
+  tags: configure
 
 - name: "Register IP of monitored node"
   set_fact:
@@ -16,18 +17,21 @@
     prometheus_node_admin_ip: "\
       {{ hostvars[inventory_hostname]['ansible_' + prometheus_blackbox_node_admin_iface]['ipv4']['address'] }}"
   when: inventory_hostname in prometheus_monitored_hosts
+  tags: configure
 
 - name: "Register IP of admin node"
   set_fact:
     prometheus_admin_ip: "\
       {{ hostvars[inventory_hostname]['ansible_'+prometheus_blackbox_admin_iface]['ipv4']['address'] }}"
   when: inventory_hostname in prometheus_admin_hosts
+  tags: configure
 
 - name: Cache hostnames
   set_fact:
     tmp_cached_hostnames: "{{ tmp_cached_hostnames | combine({item: hostvars[item]['ansible_nodename']}) }}"
   with_items: "{{ prometheus_monitored_hosts }}"
   when: inventory_hostname in prometheus_admin_hosts
+  tags: configure
 
 - name: Cache oiofs endpoints
   set_fact:
@@ -35,6 +39,7 @@
 {hostvars[item]['ansible_nodename']: hostvars[item]['oiofs_mountpoints']}) }}"
   with_items: "{{ prometheus_oiofs_hosts }}"
   when: inventory_hostname in prometheus_admin_hosts
+  tags: configure
 
 - name: Cache host data
   set_fact:
@@ -46,12 +51,14 @@
   with_dict:
     - "{{ tmp_cached_hostnames }}"
   when: inventory_hostname in prometheus_admin_hosts
+  tags: configure
 
 - name: "Cache admin IP and 'namespace' (for Jinja2)"
   set_fact:
     tmp_cached_admin_ip: "{{ prometheus_admin_ip }}"
     tmp_cached_namespace: "{{ prometheus_openio_namespace }}"
   when: inventory_hostname in prometheus_admin_hosts
+  tags: configure
 
 - name: "Fetch inventories"
   fetch:
@@ -60,6 +67,7 @@
     flat: true
   changed_when: false
   when: inventory_hostname in prometheus_monitored_hosts
+  tags: configure
 
 - name: "Load inventories as facts"
   include_vars:
@@ -69,6 +77,7 @@
   when:
     - not ansible_check_mode
     - inventory_hostname in prometheus_admin_hosts
+  tags: configure
 
 - name: "Consolidate inventories into single dict"
   set_fact:
@@ -78,6 +87,7 @@
   when:
     - not ansible_check_mode
     - inventory_hostname in prometheus_admin_hosts
+  tags: configure
 
 - name: "Generate healthchecks"
   template:
@@ -89,4 +99,5 @@
     - inventory_hostname in prometheus_admin_hosts
     - prometheus_monitored_hosts | length > 1
   register: _prometheus_healthchecks
+  tags: configure
 ...

--- a/tasks/install/CentOS.yml
+++ b/tasks/install/CentOS.yml
@@ -7,6 +7,7 @@
     gpgkey: https://packagecloud.io/prometheus-rpm/release/gpgkey
     gpgcheck: 0
   when: prometheus_upstream_package_repository
+  tags: install
 
 - name: Install
   yum:
@@ -18,4 +19,5 @@
   ignore_errors: "{{ ansible_check_mode }}"
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/install/RedHat.yml
+++ b/tasks/install/RedHat.yml
@@ -7,6 +7,7 @@
     gpgkey: https://packagecloud.io/prometheus-rpm/release/gpgkey
     gpgcheck: 0
   when: prometheus_upstream_package_repository
+  tags: install
 
 - name: Install
   yum:
@@ -18,4 +19,5 @@
   ignore_errors: "{{ ansible_check_mode }}"
   retries: 5
   delay: 2
+  tags: install
 ...

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -3,6 +3,7 @@
   apt:
     name: apt-transport-https
     state: present
+  tags: install
 
 - name: Add repository
   apt_repository:
@@ -11,12 +12,14 @@
   when:
     - ansible_distribution_release == 'xenial'
     - prometheus_upstream_package_repository
+  tags: install
 
 - name: Add Key
   apt_key:
     url: https://packagecloud.io/prometheus-deb/release/gpgkey
     state: present
   when: ansible_distribution_release == 'xenial'
+  tags: install
 
 - name: Install
   apt:
@@ -29,6 +32,7 @@
   retries: 5
   delay: 2
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: install
 
 - name: Install
   apt:
@@ -39,4 +43,5 @@
   retries: 5
   delay: 2
   ignore_errors: "{{ ansible_check_mode }}"
+  tags: install
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,12 @@
 ---
-
 - name: "Prometheus: checks"
   include: preflight.yml
+  tags: configure
 
 - block:
     - name: "Prometheus: install"
       include: "install/{{ ansible_distribution }}.yml"
+      tags: install
 
     - name: 'Prometheus: Create systemd service configuration directory'
       file:
@@ -14,6 +15,7 @@
         owner: root
         group: root
         mode: 0755
+      tags: configure
 
     - name: "Prometheus: configure systemd service limits"
       ini_file:
@@ -23,6 +25,7 @@
         value: '{{ item.value }}'
         backup: true
       with_dict: '{{ prometheus_systemd_limits }}'
+      tags: configure
 
     - name: "Prometheus: configure"
       include: "configure.yml"
@@ -34,11 +37,13 @@
         owner: "{{ prometheus_user }}"
         group: "{{ prometheus_group }}"
       register: _netdata_conf
+      tags: configure
   when: inventory_hostname in prometheus_admin_hosts
 
 - name: "Prometheus: setup healthchecks"
   include: "healthchecks.yml"
   when: prometheus_blackbox_enabled
+  tags: configure
 
 - block:
     - name: "Prometheus: (re)start service"
@@ -47,12 +52,14 @@
         daemon_reload: true
         enabled: "{{ prometheus_systemd_enabled }}"
         name: "prometheus"
+        tags: configure
 
     - name: "Prometheus: wait for service to be up"
       wait_for:
         host: "{{ prometheus_bind_address }}"
         port: "{{ prometheus_bind_port }}"
         delay: 10
+        tags: configure
   when:
     - inventory_hostname in prometheus_admin_hosts
     - _netdata_conf is changed or _prometheus_conf is changed or _prometheus_defaults is changed

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -8,6 +8,7 @@
       - blackbox_iface_admin: true
       - inventory_file: true
       - monitored_hosts: true
+  tags: configure
 
 - name: Preflight > check that at least one monitored host is defined
   set_fact:
@@ -15,6 +16,7 @@
   when:
     - prometheus_blackbox_enabled
     - prometheus_monitored_hosts | length == 0
+  tags: configure
 
 - name: Preflight > check distro
   set_fact:
@@ -23,6 +25,7 @@
     - ansible_distribution == item.distro
     - ansible_distribution_major_version == item.version | string
   with_items: "{{ prometheus_valid_distros }}"
+  tags: configure
 
 - name: Preflight > check blackbox interface on nodes (data)
   set_fact:
@@ -31,6 +34,7 @@
     - prometheus_blackbox_enabled
     - inventory_hostname in prometheus_monitored_hosts
     - ('ansible_' + prometheus_blackbox_node_data_iface) is not defined
+  tags: configure
 
 - name: Preflight > check blackbox interface on nodes (admin)
   set_fact:
@@ -39,6 +43,7 @@
     - prometheus_blackbox_enabled
     - inventory_hostname in prometheus_monitored_hosts
     - ('ansible_' + prometheus_blackbox_node_admin_iface) is not defined
+  tags: configure
 
 - name: Preflight > check blackbox interface on admin
   set_fact:
@@ -47,6 +52,7 @@
     - prometheus_blackbox_enabled
     - inventory_hostname in prometheus_admin_hosts
     - ('ansible_' + prometheus_blackbox_admin_iface) is not defined
+  tags: configure
 
 - name: Perform a stat on the inventory file
   stat:
@@ -55,6 +61,7 @@
   when:
     - prometheus_blackbox_enabled
     - inventory_hostname in prometheus_monitored_hosts
+  tags: configure
 
 - name: Preflight > check that all nodes have an inventory.yml file
   set_fact:
@@ -64,6 +71,7 @@
     - inventory_hostname in prometheus_monitored_hosts
     - not inventory_file.stat.exists
     - not ansible_check_mode
+  tags: configure
 
 # Keep this part at the end
 - name: Fail on failed checks
@@ -71,4 +79,5 @@
     msg: "Check failed: {{ item.key }}"
   when: not item.value
   with_dict: "{{ prometheus_checks }}"
+  tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION