### PR TITLE
BUGFIX/MAJOR(prometheus): Fix install on CentOS7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,6 @@ prometheus_loglevel: info
 prometheus_user: prometheus
 prometheus_group: prometheus
 prometheus_version: 2.2.1
-prometheus_upstream_package_repository: false
 prometheus_storage_path: /var/lib/prometheus/data
 prometheus_conf_dir: /etc/prometheus
 prometheus_provision_only: false

--- a/tasks/install/CentOS.yml
+++ b/tasks/install/CentOS.yml
@@ -1,16 +1,7 @@
 ---
-- name: Add repository
-  yum_repository:
-    name: prometheus
-    description: Prometheus repo
-    baseurl: https://packagecloud.io/prometheus-rpm/release/el/7/$basearch
-    gpgkey: https://packagecloud.io/prometheus-rpm/release/gpgkey
-    gpgcheck: 0
-  when: prometheus_upstream_package_repository
-
 - name: Install
   yum:
-    name: "prometheus2-{{ prometheus_version }}"
+    name: "prometheus2"
     state: present
     disable_gpg_check: true
   register: install_packages

--- a/tasks/install/RedHat.yml
+++ b/tasks/install/RedHat.yml
@@ -1,16 +1,7 @@
 ---
-- name: Add repository
-  yum_repository:
-    name: prometheus
-    description: Prometheus repo
-    baseurl: https://packagecloud.io/prometheus-rpm/release/el/7/$basearch
-    gpgkey: https://packagecloud.io/prometheus-rpm/release/gpgkey
-    gpgcheck: 0
-  when: prometheus_upstream_package_repository
-
 - name: Install
   yum:
-    name: "prometheus2-{{ prometheus_version }}"
+    name: "prometheus2"
     state: present
     disable_gpg_check: true
   register: install_packages

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -10,7 +10,6 @@
     state: present
   when:
     - ansible_distribution_release == 'xenial'
-    - prometheus_upstream_package_repository
 
 - name: Add Key
   apt_key:


### PR DESCRIPTION
 ##### SUMMARY

When using the OpenIO repository and enforcing a specific version, the
install fails with 'package not found'. This PR fixes this behavior.

Also, the package_upstream option is removed; in the future the package
will come exclusively from OpenIO repos. For now it is only the case for
CentOS7

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION