### PR TITLE
BUGFIX/MAJOR(prometheus): Fix writeable tempdir

### DIFF
--- a/tasks/healthchecks.yml
+++ b/tasks/healthchecks.yml
@@ -69,6 +69,16 @@
   changed_when: false
   tags: configure
 
+- name: Make temporary directory writeable
+  local_action:
+    module: file
+    path: "{{ inv_dir.path }}"
+    owner: root
+    group: root
+    mode: '0777'
+  changed_when: false
+  tags: configure
+
 - name: "Fetch inventories"
   fetch:
     src: "/etc/oio/sds/{{ prometheus_openio_namespace }}/inventory.yml"


### PR DESCRIPTION
 ##### SUMMARY

Temporary directory created for healthchecks wasn't writeable, causing
Permission Denied issues (in conjunction with become=true); This makes it properly accessible to all users

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION