### PR TITLE
BUGFIX/MINOR(prometheus): Fix temporary directory for inventories

### DIFF
--- a/tasks/healthchecks.yml
+++ b/tasks/healthchecks.yml
@@ -68,6 +68,7 @@
   run_once: true
   changed_when: false
   tags: configure
+  become: false
 
 - name: "Fetch inventories"
   fetch:


### PR DESCRIPTION
 ##### SUMMARY

The fetching of inventories is broken
```console
TASK [prometheus : Fetch inventories] **********************************************************************************************************************************************************************
Thursday 13 June 2019  09:23:31 +0000 (0:00:00.479)       0:00:45.823 *********
fatal: [node3]: FAILED! =>
  msg: 'Unable to create local directories(/tmp/ansible.2fEoCFinventory/OPENIO): [Errno 13] Permission denied: ''/tmp/ansible.2fEoCFinventory/OPENIO'''
fatal: [node1]: FAILED! =>
  msg: 'Unable to create local directories(/tmp/ansible.2fEoCFinventory/OPENIO): [Errno 13] Permission denied: ''/tmp/ansible.2fEoCFinventory/OPENIO'''
fatal: [node5]: FAILED! =>
  msg: 'Unable to create local directories(/tmp/ansible.2fEoCFinventory/OPENIO): [Errno 13] Permission denied: ''/tmp/ansible.2fEoCFinventory/OPENIO'''
fatal: [node2]: FAILED! =>
  msg: 'Unable to create local directories(/tmp/ansible.2fEoCFinventory/OPENIO): [Errno 13] Permission denied: ''/tmp/ansible.2fEoCFinventory/OPENIO'''
fatal: [node4]: FAILED! =>
  msg: 'Unable to create local directories(/tmp/ansible.2fEoCFinventory/OPENIO): [Errno 13] Permission denied: ''/tmp/ansible.2fEoCFinventory/OPENIO'''
fatal: node6]: FAILED! =>
  msg: 'Unable to create local directories(/tmp/ansible.2fEoCFinventory/OPENIO): [Errno 13] Permission denied: ''/tmp/ansible.2fEoCFinventory/OPENIO'''
```
 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION