### PR TITLE
BUGFIX/MAJOR(prometheus): Revert removed consolidate facts

### DIFF
--- a/docker-tests/inventory.yml
+++ b/docker-tests/inventory.yml
@@ -1,12 +1,12 @@
 ---
 created_at: '2018-10-18T15:00:21.726800Z'
 namespaces:
-  OPENIO:
+  TRAVIS:
     config: {}
     services:
       account:
         - config: {}
-          id: OPENIO-account-0
+          id: TRAVIS-account-0
           ip: 10.0.0.91
           location: node11.0
           partition: ''
@@ -14,15 +14,15 @@ namespaces:
           volume: ''
       beanstalkd:
         - config: {}
-          id: OPENIO-beanstalkd-0
+          id: TRAVIS-beanstalkd-0
           ip: 10.0.0.91
           location: ''
           partition: ''
           port: 6014
-          volume: /mnt/ssd/OPENIO/beanstalkd-0
+          volume: /mnt/ssd/TRAVIS/beanstalkd-0
       conscience:
         - config: {}
-          id: OPENIO-conscience-0
+          id: TRAVIS-conscience-0
           ip: 10.0.0.91
           location: ''
           partition: ''
@@ -30,7 +30,7 @@ namespaces:
           volume: ''
       conscienceagent:
         - config: {}
-          id: OPENIO-conscienceagent-0
+          id: TRAVIS-conscienceagent-0
           ip: ''
           location: ''
           partition: ''
@@ -62,14 +62,14 @@ namespaces:
           volume: ''
       keystone:
         - config: {}
-          id: OPENIO-keystone-0.0
+          id: TRAVIS-keystone-0.0
           ip: 10.0.0.91
           location: ''
           partition: ''
           port: 5000
           volume: ''
         - config: {}
-          id: OPENIO-keystone-0.1
+          id: TRAVIS-keystone-0.1
           ip: 10.0.0.91
           location: ''
           partition: ''
@@ -77,7 +77,7 @@ namespaces:
           volume: ''
       memcached:
         - config: {}
-          id: OPENIO-memcached-0
+          id: TRAVIS-memcached-0
           ip: 10.0.0.91
           location: ''
           partition: ''
@@ -85,214 +85,214 @@ namespaces:
           volume: ''
       meta0:
         - config: {}
-          id: OPENIO-meta0-0
+          id: TRAVIS-meta0-0
           ip: 10.0.0.91
           location: node11.0
           partition: /dev/vdb
           port: 6001
-          volume: /mnt/ssd/OPENIO/meta0-0
+          volume: /mnt/ssd/TRAVIS/meta0-0
       meta1:
         - config: {}
-          id: OPENIO-meta1-0
+          id: TRAVIS-meta1-0
           ip: 10.0.0.91
           location: node11.0
           partition: /dev/vdb
           port: 6110
-          volume: /mnt/ssd/OPENIO/meta1-0
+          volume: /mnt/ssd/TRAVIS/meta1-0
         - config: {}
-          id: OPENIO-meta1-1
+          id: TRAVIS-meta1-1
           ip: 10.0.0.91
           location: node11.1
           partition: /dev/vdd
           port: 6111
-          volume: /mnt/ssd2/OPENIO/meta1-1
+          volume: /mnt/ssd2/TRAVIS/meta1-1
         - config: {}
-          id: OPENIO-meta1-2
+          id: TRAVIS-meta1-2
           ip: 10.0.0.91
           location: node11.2
           partition: /dev/vde
           port: 6112
-          volume: /mnt/ssd3/OPENIO/meta1-2
+          volume: /mnt/ssd3/TRAVIS/meta1-2
       meta2:
         - config: {}
-          id: OPENIO-meta2-0
+          id: TRAVIS-meta2-0
           ip: 10.0.0.91
           location: node11.0
           partition: /dev/vdb
           port: 6120
-          volume: /mnt/ssd/OPENIO/meta2-0
+          volume: /mnt/ssd/TRAVIS/meta2-0
         - config: {}
-          id: OPENIO-meta2-1
+          id: TRAVIS-meta2-1
           ip: 10.0.0.91
           location: node11.1
           partition: /dev/vdb
           port: 6121
-          volume: /mnt/ssd/OPENIO/meta2-1
+          volume: /mnt/ssd/TRAVIS/meta2-1
         - config: {}
-          id: OPENIO-meta2-2
+          id: TRAVIS-meta2-2
           ip: 10.0.0.91
           location: node11.2
           partition: /dev/vdb
           port: 6122
-          volume: /mnt/ssd/OPENIO/meta2-2
+          volume: /mnt/ssd/TRAVIS/meta2-2
         - config: {}
-          id: OPENIO-meta2-3
+          id: TRAVIS-meta2-3
           ip: 10.0.0.91
           location: node11.3
           partition: /dev/vdb
           port: 6123
-          volume: /mnt/ssd/OPENIO/meta2-3
+          volume: /mnt/ssd/TRAVIS/meta2-3
         - config: {}
-          id: OPENIO-meta2-4
+          id: TRAVIS-meta2-4
           ip: 10.0.0.91
           location: node11.4
           partition: /dev/vdb
           port: 6124
-          volume: /mnt/ssd/OPENIO/meta2-4
+          volume: /mnt/ssd/TRAVIS/meta2-4
         - config: {}
-          id: OPENIO-meta2-5
+          id: TRAVIS-meta2-5
           ip: 10.0.0.91
           location: node11.5
           partition: /dev/vdb
           port: 6125
-          volume: /mnt/ssd/OPENIO/meta2-5
+          volume: /mnt/ssd/TRAVIS/meta2-5
         - config: {}
-          id: OPENIO-meta2-6
+          id: TRAVIS-meta2-6
           ip: 10.0.0.91
           location: node11.6
           partition: /dev/vdb
           port: 6126
-          volume: /mnt/ssd/OPENIO/meta2-6
+          volume: /mnt/ssd/TRAVIS/meta2-6
         - config: {}
-          id: OPENIO-meta2-7
+          id: TRAVIS-meta2-7
           ip: 10.0.0.91
           location: node11.7
           partition: /dev/vdb
           port: 6127
-          volume: /mnt/ssd/OPENIO/meta2-7
+          volume: /mnt/ssd/TRAVIS/meta2-7
         - config: {}
-          id: OPENIO-meta2-8
+          id: TRAVIS-meta2-8
           ip: 10.0.0.91
           location: node11.8
           partition: /dev/vdd
           port: 6128
-          volume: /mnt/ssd2/OPENIO/meta2-8
+          volume: /mnt/ssd2/TRAVIS/meta2-8
         - config: {}
-          id: OPENIO-meta2-9
+          id: TRAVIS-meta2-9
           ip: 10.0.0.91
           location: node11.9
           partition: /dev/vdd
           port: 6129
-          volume: /mnt/ssd2/OPENIO/meta2-9
+          volume: /mnt/ssd2/TRAVIS/meta2-9
         - config: {}
-          id: OPENIO-meta2-10
+          id: TRAVIS-meta2-10
           ip: 10.0.0.91
           location: node11.10
           partition: /dev/vdd
           port: 6130
-          volume: /mnt/ssd2/OPENIO/meta2-10
+          volume: /mnt/ssd2/TRAVIS/meta2-10
         - config: {}
-          id: OPENIO-meta2-11
+          id: TRAVIS-meta2-11
           ip: 10.0.0.91
           location: node11.11
           partition: /dev/vdd
           port: 6131
-          volume: /mnt/ssd2/OPENIO/meta2-11
+          volume: /mnt/ssd2/TRAVIS/meta2-11
         - config: {}
-          id: OPENIO-meta2-12
+          id: TRAVIS-meta2-12
           ip: 10.0.0.91
           location: node11.12
           partition: /dev/vdd
           port: 6132
-          volume: /mnt/ssd2/OPENIO/meta2-12
+          volume: /mnt/ssd2/TRAVIS/meta2-12
         - config: {}
-          id: OPENIO-meta2-13
+          id: TRAVIS-meta2-13
           ip: 10.0.0.91
           location: node11.13
           partition: /dev/vdd
           port: 6133
-          volume: /mnt/ssd2/OPENIO/meta2-13
+          volume: /mnt/ssd2/TRAVIS/meta2-13
         - config: {}
-          id: OPENIO-meta2-14
+          id: TRAVIS-meta2-14
           ip: 10.0.0.91
           location: node11.14
           partition: /dev/vdd
           port: 6134
-          volume: /mnt/ssd2/OPENIO/meta2-14
+          volume: /mnt/ssd2/TRAVIS/meta2-14
         - config: {}
-          id: OPENIO-meta2-15
+          id: TRAVIS-meta2-15
           ip: 10.0.0.91
           location: node11.15
           partition: /dev/vdd
           port: 6135
-          volume: /mnt/ssd2/OPENIO/meta2-15
+          volume: /mnt/ssd2/TRAVIS/meta2-15
         - config: {}
-          id: OPENIO-meta2-16
+          id: TRAVIS-meta2-16
           ip: 10.0.0.91
           location: node11.16
           partition: /dev/vde
           port: 6136
-          volume: /mnt/ssd3/OPENIO/meta2-16
+          volume: /mnt/ssd3/TRAVIS/meta2-16
         - config: {}
-          id: OPENIO-meta2-17
+          id: TRAVIS-meta2-17
           ip: 10.0.0.91
           location: node11.17
           partition: /dev/vde
           port: 6137
-          volume: /mnt/ssd3/OPENIO/meta2-17
+          volume: /mnt/ssd3/TRAVIS/meta2-17
         - config: {}
-          id: OPENIO-meta2-18
+          id: TRAVIS-meta2-18
           ip: 10.0.0.91
           location: node11.18
           partition: /dev/vde
           port: 6138
-          volume: /mnt/ssd3/OPENIO/meta2-18
+          volume: /mnt/ssd3/TRAVIS/meta2-18
         - config: {}
-          id: OPENIO-meta2-19
+          id: TRAVIS-meta2-19
           ip: 10.0.0.91
           location: node11.19
           partition: /dev/vde
           port: 6139
-          volume: /mnt/ssd3/OPENIO/meta2-19
+          volume: /mnt/ssd3/TRAVIS/meta2-19
         - config: {}
-          id: OPENIO-meta2-20
+          id: TRAVIS-meta2-20
           ip: 10.0.0.91
           location: node11.20
           partition: /dev/vde
           port: 6140
-          volume: /mnt/ssd3/OPENIO/meta2-20
+          volume: /mnt/ssd3/TRAVIS/meta2-20
         - config: {}
-          id: OPENIO-meta2-21
+          id: TRAVIS-meta2-21
           ip: 10.0.0.91
           location: node11.21
           partition: /dev/vde
           port: 6141
-          volume: /mnt/ssd3/OPENIO/meta2-21
+          volume: /mnt/ssd3/TRAVIS/meta2-21
         - config: {}
-          id: OPENIO-meta2-22
+          id: TRAVIS-meta2-22
           ip: 10.0.0.91
           location: node11.22
           partition: /dev/vde
           port: 6142
-          volume: /mnt/ssd3/OPENIO/meta2-22
+          volume: /mnt/ssd3/TRAVIS/meta2-22
         - config: {}
-          id: OPENIO-meta2-23
+          id: TRAVIS-meta2-23
           ip: 10.0.0.91
           location: node11.23
           partition: /dev/vde
           port: 6143
-          volume: /mnt/ssd3/OPENIO/meta2-23
+          volume: /mnt/ssd3/TRAVIS/meta2-23
       oioblobindexer:
         - config: {}
-          id: OPENIO-oioblobindexer-0
+          id: TRAVIS-oioblobindexer-0
           ip: 10.0.0.91
           location: node11.0
           partition: /dev/vdc
           port: 0
-          volume: /mnt/hdd/OPENIO/rawx-0
+          volume: /mnt/hdd/TRAVIS/rawx-0
       oioblobrebuilder:
         - config: {}
-          id: OPENIO-oioblobrebuilder-0
+          id: TRAVIS-oioblobrebuilder-0
           ip: ''
           location: ''
           partition: ''
@@ -300,7 +300,7 @@ namespaces:
           volume: ''
       oioeventagent:
         - config: {}
-          id: OPENIO-oioeventagent-0
+          id: TRAVIS-oioeventagent-0
           ip: ''
           location: node11.0
           partition: ''
@@ -308,7 +308,7 @@ namespaces:
           volume: ''
       oioproxy:
         - config: {}
-          id: OPENIO-oioproxy-0
+          id: TRAVIS-oioproxy-0
           ip: 10.0.0.91
           location: ''
           partition: ''
@@ -316,7 +316,7 @@ namespaces:
           volume: ''
       oioswift:
         - config: {}
-          id: OPENIO-oioswift-0
+          id: TRAVIS-oioswift-0
           ip: 10.0.0.91
           location: ''
           partition: ''
@@ -324,43 +324,43 @@ namespaces:
           volume: ''
       rawx:
         - config: {}
-          id: OPENIO-rawx-0
+          id: TRAVIS-rawx-0
           ip: 10.0.0.91
           location: node11.0
           partition: /dev/vdc
           port: 6200
-          volume: /mnt/hdd/OPENIO/rawx-0
+          volume: /mnt/hdd/TRAVIS/rawx-0
       rdir:
         - config: {}
-          id: OPENIO-rdir-0
+          id: TRAVIS-rdir-0
           ip: 10.0.0.91
           location: node11.0
           partition: /dev/vdc
           port: 6300
-          volume: /mnt/hdd/OPENIO/rdir-0
+          volume: /mnt/hdd/TRAVIS/rdir-0
       redis:
         - config: {}
-          id: OPENIO-redis-0
+          id: TRAVIS-redis-0
           ip: 10.0.0.91
           location: ''
           partition: ''
           port: 6011
-          volume: /mnt/ssd/OPENIO/redis-0
+          volume: /mnt/ssd/TRAVIS/redis-0
       redissentinel:
         - config: {}
-          id: OPENIO-redissentinel-0
+          id: TRAVIS-redissentinel-0
           ip: 10.0.0.91
           location: ''
           partition: ''
           port: 6012
-          volume: /mnt/ssd/OPENIO/redissentinel-0
+          volume: /mnt/ssd/TRAVIS/redissentinel-0
       zookeeper:
         - config: {}
-          id: OPENIO-zookeeper-0
+          id: TRAVIS-zookeeper-0
           ip: 10.0.0.91
           location: ''
           partition: ''
           port: 6005
-          volume: /mnt/ssd/OPENIO/zookeeper-0
+          volume: /mnt/ssd/TRAVIS/zookeeper-0
 
 ...

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -19,5 +19,5 @@
       openio_repository_mirror_host: mirror2.openio.io
     - role: role_under_test
       prometheus_admin_hosts: [ 'localhost' ]
-      prometheus_monitored_hosts: [ 'localhost' ]
+      prometheus_monitored_hosts: [ 'localhost', 'localhost' ]
 ...

--- a/docker-tests/tests.bats
+++ b/docker-tests/tests.bats
@@ -32,3 +32,17 @@
   echo "output: "$output
   [[ "${status}" -eq "0" ]]
 }
+
+@test 'Healthchecks for services defined in inventory are set up' {
+    run bash -c "docker exec -ti ${SUT_ID} grep '=>10.0.0.91:6006' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+
+    run bash -c "docker exec -ti ${SUT_ID} grep '=>10.0.0.91:6000' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+
+    run bash -c "docker exec -ti ${SUT_ID} grep '=>10.0.0.91:6137' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+}

--- a/tasks/healthchecks.yml
+++ b/tasks/healthchecks.yml
@@ -89,6 +89,15 @@
     - inventory_hostname in prometheus_admin_hosts
   tags: configure
 
+- name: "Consolidate inventories into single dict"
+  set_fact:
+    tmp_cached_inventory: "{{ tmp_cached_inventory |\
+      combine({item.key: hostvars[inventory_hostname][item.value]}) }}"
+  with_dict: "{{ tmp_cached_inventories }}"
+  when:
+    - not ansible_check_mode
+    - inventory_hostname in prometheus_admin_hosts
+
 - name: "Generate healthchecks"
   template:
     src: blackbox.yml.j2


### PR DESCRIPTION
 ##### SUMMARY

Consolidate facts has been removed by a previous commit but it is
necessary. This reverts it and adds a functional test to make sure all
healthchecks are generated properly in CI.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION