### PR TITLE
CHANGE(prometheus): Use new metric labels in aggregations

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,17 +7,17 @@ prometheus_aggregation_rules:
         expr: "avg(label_replace(netdata_openio_score__average, \"dim2\", \"$1\", \"dimension\", \"(.*?)[_].*\")) \
 by (dim2)"
       - record: "aggr:netdata_web_log_bandwidth:sum"
-        expr: "sum(label_replace(netdata_web_log_bandwidth_kilobits_persec_average, \
-\"chart2\", \"$1\", \"chart\", \".*openio[.](.*)[.].*.log.*\")) by (chart2, instance, dimension)"
+        expr: "sum(label_replace(netdata_web_log_bandwidth_kilobits_persec_average, 'type','$1',\
+        'service','(.*)-.*')) by (instance, dimension, type)"
       - record: "aggr:netdata_web_log_response_codes:sum"
-        expr: "sum(label_replace(netdata_web_log_response_codes_requests_persec_average, \
-\"chart2\", \"$1\", \"chart\", \".*openio[.](.*)[.].*.log.*\")) by (chart2, instance, dimension)"
+        expr: "sum(label_replace(netdata_web_log_response_codes_requests_persec_average, 'type','$1',\
+        'service','(.*)-.*')) by (instance, dimension, type)"
       - record: "aggr:netdata_web_log_http_request_methods:sum"
-        expr: "sum(label_replace(netdata_web_log_http_method_requests_persec_average, \
-\"chart2\", \"$1\", \"chart\", \".*openio[.](.*)[.].*.log.*\")) by (chart2, instance, dimension)"
+        expr: "sum(label_replace(netdata_web_log_http_method_requests_persec_average, 'type','$1',\
+        'service','(.*)-.*')) by (instance, dimension, type)"
       - record: "aggr:netdata_web_log_response_time_ms:sum"
-        expr: "sum(label_replace(netdata_web_log_response_time_milliseconds_average, \
-\"chart2\", \"$1\", \"chart\", \".*openio[.](.*)[.].*.log.*\")) by (chart2, instance, dimension)"
+        expr: "sum(label_replace(netdata_web_log_response_time_milliseconds_average, 'type','$1',\
+        'service','(.*)-.*')) by (instance, dimension, type)"
 
 prometheus_valid_distros:
   - distro: Ubuntu


### PR DESCRIPTION
 ##### SUMMARY

Now that the service is tagged in web_log metrics, we can easily deduce
the service type. This is used in metric aggregations

 ##### IMPACT
Label chart2 renamed to type

 ##### ADDITIONAL INFORMATION