### PR TITLE
BUGFIX/MEDIUM(prometheus): Fix interface used to contact blackbox

### DIFF
--- a/docker-tests/tests.bats
+++ b/docker-tests/tests.bats
@@ -34,15 +34,28 @@
 }
 
 @test 'Healthchecks for services defined in inventory are set up' {
-    run bash -c "docker exec -ti ${SUT_ID} grep '=>10.0.0.91:6006' /etc/prometheus/targets/blackbox.yml"
+    # OIOPROXY
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>10.0.0.91:6006' /etc/prometheus/targets/blackbox.yml"
     echo "output: "$output
     [[ "${status}" -eq "0" ]]
 
-    run bash -c "docker exec -ti ${SUT_ID} grep '=>10.0.0.91:6000' /etc/prometheus/targets/blackbox.yml"
+    # CONSCIENCE
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>10.0.0.91:6000' /etc/prometheus/targets/blackbox.yml"
     echo "output: "$output
     [[ "${status}" -eq "0" ]]
 
-    run bash -c "docker exec -ti ${SUT_ID} grep '=>10.0.0.91:6137' /etc/prometheus/targets/blackbox.yml"
+    # META2
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>10.0.0.91:6137' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+
+    # BLACKBOX SELF-CHECK
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>${SUT_IP}:9115' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+
+    # ICMP
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>${SUT_IP}' /etc/prometheus/targets/blackbox.yml"
     echo "output: "$output
     [[ "${status}" -eq "0" ]]
 }

--- a/templates/blackbox.yml.j2
+++ b/templates/blackbox.yml.j2
@@ -12,7 +12,7 @@
 {% for svc in prometheus_tcpcheck_services %}
 {% for hostname, data in tmp_cached_inventory.iteritems() %}
     {% set hloop = loop %}
-    {% set src_ip = tmp_cached_node_data_ip[tmp_cached_node_data_ip.keys()[0 if hloop.last else hloop.index]] %}
+    {% set src_ip = tmp_cached_node_admin_ip[tmp_cached_node_admin_ip.keys()[0 if hloop.last else hloop.index]] %}
         {% for instance in data.namespaces[tmp_cached_namespace].services.get(svc, []) %}
 - labels:
     module: tcpcheck
@@ -42,7 +42,7 @@
 {% for svc in prometheus_oioping_services %}
     {% for hostname, data in tmp_cached_inventory.iteritems() %}
         {% set hloop = loop %}
-        {% set src_ip = tmp_cached_node_data_ip[tmp_cached_node_data_ip.keys()[0 if hloop.last else hloop.index]] %}
+        {% set src_ip = tmp_cached_node_admin_ip[tmp_cached_node_admin_ip.keys()[0 if hloop.last else hloop.index]] %}
         {% for instance in data.namespaces[tmp_cached_namespace].services.get(svc, []) %}
 - labels:
     module: oioping
@@ -59,7 +59,7 @@
     {% for hostname, data in tmp_cached_inventory.iteritems() %}
         {% set hloop = loop %}
         {% set services = data.namespaces[tmp_cached_namespace].services %}
-        {% set src_ip = tmp_cached_node_data_ip[tmp_cached_node_data_ip.keys()[0 if hloop.last else hloop.index]] %}
+        {% set src_ip = tmp_cached_node_admin_ip[tmp_cached_node_admin_ip.keys()[0 if hloop.last else hloop.index]] %}
         {% for instance in services.get(module, []) %}
 - labels:
     module: "{{ module }}"


### PR DESCRIPTION
 ##### SUMMARY

Due to a recent rewrite brought by #37, the blackbox interface used as
src_ip was the node's data interface. This fixes the behavior and
ensures that the correct (node management) IP is used by adding a functional test.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION