### PR TITLE
BUGFIX/MINOR(prometheus): Fix deployment using various networks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,16 @@ script:
   - yamllint .
 
   # Create container and apply test playbook
-  - ./docker-tests/docker-tests.sh
+  - ./docker-tests/docker-tests.sh test_default
+  - ./docker-tests/docker-tests.sh test_iface
+  - ./docker-tests/docker-tests.sh test_addr
+  - ./docker-tests/docker-tests.sh test_all
+
 
   # Run functional tests on the container
   # - SUT_ID=$(docker ps -qa) ./docker-tests/functional-tests.sh
-  - SUT_IP=172.17.0.2 SUT_ID=$(docker ps -qa) ./docker-tests/functional-tests.sh
+  - SUT_IP=172.17.0.2 SUT_ID=$(docker ps -qa | tail -n 1) ./docker-tests/functional-tests.sh
+  - SUT_IP=172.18.0.3 SUT_ID=$(docker ps -qa | tail -n 2 | head -n 1) ./docker-tests/functional-tests.sh
+  - SUT_IP=172.18.0.4 SUT_ID=$(docker ps -qa | head -n 2 | tail -n 1) ./docker-tests/functional-tests.sh
+  - SUT_IP=172.18.0.5 SUT_ID=$(docker ps -qa | head -n 1) ./docker-tests/functional-tests.sh
 ...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,9 +44,6 @@ prometheus_netdata_bind_interface: "{{ openio_bind_mgmt_interface | d(ansible_de
 # Collection: blackbox
 prometheus_blackbox_interval: 10s
 prometheus_blackbox_port: 9115
-prometheus_blackbox_node_data_iface: "{{ openio_bind_interface | d(ansible_default_ipv4.alias) }}"
-prometheus_blackbox_node_admin_iface: "{{ openio_bind_mgmt_interface | d(ansible_default_ipv4.alias) }}"
-prometheus_blackbox_admin_iface: "{{ openio_bind_mgmt_interface | d(ansible_default_ipv4.alias) }}"
 
 # Collection: alertmanager
 prometheus_alertmanager_port: 9093

--- a/docker-tests/docker-tests.sh
+++ b/docker-tests/docker-tests.sh
@@ -111,6 +111,8 @@ start_container() {
     "${image_tag}" \
     "${init}" \
     > "${container_id}"
+  docker network create net2 --driver bridge || true
+  docker network connect net2 $(cat ${container_id})
   set +x
 }
 

--- a/docker-tests/mgmt.bats
+++ b/docker-tests/mgmt.bats
@@ -1,0 +1,78 @@
+#! /usr/bin/env bats
+
+# Variable SUT_IP should be set outside this script and should contain the IP
+# address of the System Under Test.
+
+# Tests
+run_only_test() {
+  if [[ "$SUT_IP" != "$1" ]] && [[ "$SUT_IP" != "$2" ]] && [[ "$SUT_IP" != "$2" ]]; then
+    skip
+  fi
+}
+
+setup() {
+  run_only_test "172.18.0.3" "172.18.0.4" "172.18.0.5"
+}
+
+
+@test 'Prometheus listens 9090' {
+  run bash -c "curl http://${SUT_IP}:9090/metrics"
+  echo "output: "$output
+  echo "status: "$status
+  [[ "${status}" -eq "0" ]]
+  [[ "${output}" =~ 'go_goroutines' ]]
+}
+
+@test 'Prometheus defaults file exists and is correct' {
+  run bash -c "docker exec -ti ${SUT_ID} cat /etc/default/prometheus"
+  echo "output: "$output
+  echo "status: "$status
+  [[ "${status}" -eq "0" ]]
+  [[ "${output}" =~ 'storage.tsdb.path=/var/lib/prometheus/data' ]]
+}
+
+@test 'Prometheus config file exists' {
+  run bash -c "docker exec -ti ${SUT_ID} cat /etc/prometheus/prometheus.yml"
+  echo "output: "$output
+  [[ "${status}" -eq "0" ]]
+}
+
+@test 'Netdata rules are added' {
+  run bash -c "docker exec -ti ${SUT_ID} cat /etc/prometheus/targets/netdata.yml"
+  echo "output: "$output
+  [[ "${status}" -eq "0" ]]
+}
+
+@test 'Healthchecks for services defined in inventory are set up' {
+    # OIOPROXY
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>10.0.0.91:6006' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+
+    # CONSCIENCE
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>10.0.0.91:6000' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+
+    # META2
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>10.0.0.91:6137' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+
+    # BLACKBOX SELF-CHECK
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>${SUT_IP}:9115' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+
+    # ICMP
+    run bash -c "docker exec -ti ${SUT_ID} grep '${SUT_IP}=>${SUT_IP}' /etc/prometheus/targets/blackbox.yml"
+    echo "output: "$output
+    [[ "${status}" -eq "0" ]]
+}
+
+@test 'All targets contain valid YAML' {
+    run bash -c "docker exec -ti ${SUT_ID} find /etc/prometheus/ -name \*.yml -exec python -c \
+    'import sys,yaml; yaml.load(open(sys.argv[1]).read(), Loader=yaml.SafeLoader);' {} \;"
+    echo "output: "$output
+    [[ "${output}" -eq "" ]]
+}

--- a/docker-tests/test_addr.yml
+++ b/docker-tests/test_addr.yml
@@ -1,0 +1,29 @@
+# Test playbook
+---
+- name: "Test playbook using management address"
+  hosts: "all"
+  become: true
+  vars:
+    namespace: TRAVIS
+  pre_tasks:
+    - name: Seed directory for NS
+      file:
+        path: "/etc/oio/sds/{{ namespace }}"
+        state: directory
+    - name: Seed inventory on nodes
+      copy:
+        src: inventory.yml
+        dest: "/etc/oio/sds/{{ namespace }}/inventory.yml"
+    - name: Setup networking
+      set_fact:
+        openio_bind_mgmt_address: "{{ ansible_eth1.ipv4.address }}"
+        openio_bind_address: "{{ ansible_default_ipv4.address }}"
+  roles:
+    - role: repo
+      openio_repository_no_log: false
+      openio_repository_mirror_host: mirror2.openio.io
+    - role: role_under_test
+      prometheus_netdata_group: all
+      prometheus_admin_hosts: [ 'localhost' ]
+      prometheus_monitored_hosts: [ 'localhost', 'localhost' ]
+...

--- a/docker-tests/test_all.yml
+++ b/docker-tests/test_all.yml
@@ -1,6 +1,7 @@
 # Test playbook
 ---
-- hosts: all
+- name: "Test playbook using management interface and address"
+  hosts: "all"
   become: true
   vars:
     namespace: TRAVIS
@@ -13,6 +14,11 @@
       copy:
         src: inventory.yml
         dest: "/etc/oio/sds/{{ namespace }}/inventory.yml"
+    - name: Setup networking
+      set_fact:
+        openio_bind_mgmt_address: "{{ ansible_eth1.ipv4.address }}"
+        openio_bind_mgmt_interface: "eth1"
+        openio_bind_address: "{{ ansible_default_ipv4.address }}"
   roles:
     - role: repo
       openio_repository_no_log: false

--- a/docker-tests/test_default.yml
+++ b/docker-tests/test_default.yml
@@ -1,0 +1,28 @@
+# Test playbook
+---
+- name: "Test playbook using default networking"
+  hosts: "all"
+  become: true
+  vars:
+    namespace: TRAVIS
+  pre_tasks:
+    - name: Seed directory for NS
+      file:
+        path: "/etc/oio/sds/{{ namespace }}"
+        state: directory
+    - name: Seed inventory on nodes
+      copy:
+        src: inventory.yml
+        dest: "/etc/oio/sds/{{ namespace }}/inventory.yml"
+    - name: Setup networking
+      set_fact:
+        openio_bind_address: "{{ ansible_default_ipv4.address }}"
+  roles:
+    - role: repo
+      openio_repository_no_log: false
+      openio_repository_mirror_host: mirror2.openio.io
+    - role: role_under_test
+      prometheus_netdata_group: all
+      prometheus_admin_hosts: [ 'localhost' ]
+      prometheus_monitored_hosts: [ 'localhost', 'localhost' ]
+...

--- a/docker-tests/test_iface.yml
+++ b/docker-tests/test_iface.yml
@@ -1,0 +1,29 @@
+# Test playbook
+---
+- name: "Test playbook using management interface"
+  hosts: "all"
+  become: true
+  vars:
+    namespace: TRAVIS
+  pre_tasks:
+    - name: Seed directory for NS
+      file:
+        path: "/etc/oio/sds/{{ namespace }}"
+        state: directory
+    - name: Seed inventory on nodes
+      copy:
+        src: inventory.yml
+        dest: "/etc/oio/sds/{{ namespace }}/inventory.yml"
+    - name: Set openio_bind_mgmt_iface
+      set_fact:
+        openio_bind_address: "{{ ansible_default_ipv4.address }}"
+        openio_bind_mgmt_interface: "eth1"
+  roles:
+    - role: repo
+      openio_repository_no_log: false
+      openio_repository_mirror_host: mirror2.openio.io
+    - role: role_under_test
+      prometheus_netdata_group: all
+      prometheus_admin_hosts: [ 'localhost' ]
+      prometheus_monitored_hosts: [ 'localhost', 'localhost' ]
+...

--- a/docker-tests/tests_default.bats
+++ b/docker-tests/tests_default.bats
@@ -4,6 +4,16 @@
 # address of the System Under Test.
 
 # Tests
+run_only_test() {
+  if [[ "$SUT_IP" != "$1" ]]; then
+    skip
+  fi
+}
+
+setup() {
+  run_only_test "172.17.0.2"
+}
+
 
 @test 'Prometheus listens 9090' {
   run bash -c "curl http://${SUT_IP}:9090/metrics"

--- a/tasks/healthchecks.yml
+++ b/tasks/healthchecks.yml
@@ -10,20 +10,50 @@
     tmp_cached_namespace: ""
   tags: configure
 
-- name: "Register IP of monitored node"
+- name: "Register data IP of monitored node"
   set_fact:
     prometheus_node_data_ip: "\
-      {{ hostvars[inventory_hostname]['ansible_' + prometheus_blackbox_node_data_iface]['ipv4']['address'] }}"
-    prometheus_node_admin_ip: "\
-      {{ hostvars[inventory_hostname]['ansible_' + prometheus_blackbox_node_admin_iface]['ipv4']['address'] }}"
+      {{ hostvars[inventory_hostname]['openio_bind_address'] }}"
   when: inventory_hostname in prometheus_monitored_hosts
   tags: configure
 
-- name: "Register IP of admin node"
+- name: "Register admin IP of monitored node (with mgmt interface)"
+  set_fact:
+    prometheus_node_admin_ip: "\
+        {{ hostvars[inventory_hostname].get('openio_bind_mgmt_address',
+  hostvars[inventory_hostname]['ansible_' + openio_bind_mgmt_interface]['ipv4']['address']) }}"
+  when:
+    - inventory_hostname in prometheus_monitored_hosts
+    - openio_bind_mgmt_interface is defined
+  tags: configure
+
+- name: "Register admin IP of monitored node (default)"
+  set_fact:
+    prometheus_node_admin_ip: "{{ hostvars[inventory_hostname].get('openio_bind_mgmt_address',
+  hostvars[inventory_hostname]['openio_bind_address']) }}"
+  when:
+    - inventory_hostname in prometheus_monitored_hosts
+    - openio_bind_mgmt_interface is not defined
+  tags: configure
+
+- name: "Register IP of admin node (with mgmt interface)"
   set_fact:
     prometheus_admin_ip: "\
-      {{ hostvars[inventory_hostname]['ansible_'+prometheus_blackbox_admin_iface]['ipv4']['address'] }}"
-  when: inventory_hostname in prometheus_admin_hosts
+      {{ hostvars[inventory_hostname].get('openio_bind_mgmt_address',\
+hostvars[inventory_hostname]['ansible_' + openio_bind_mgmt_interface]['ipv4']['address']) }}"
+  when:
+    - inventory_hostname in prometheus_admin_hosts
+    - openio_bind_mgmt_interface is defined
+  tags: configure
+
+- name: "Register IP of admin node (default)"
+  set_fact:
+    prometheus_admin_ip: "\
+      {{ hostvars[inventory_hostname].get('openio_bind_mgmt_address',
+hostvars[inventory_hostname]['openio_bind_address']) }}"
+  when:
+    - inventory_hostname in prometheus_admin_hosts
+    - openio_bind_mgmt_interface is not defined
   tags: configure
 
 - name: Cache hostnames

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -3,9 +3,6 @@
   set_fact:
     prometheus_checks:
       - distro: false
-      - blackbox_iface_node_data: true
-      - blackbox_iface_node_admin: true
-      - blackbox_iface_admin: true
       - inventory_file: true
       - monitored_hosts: true
   tags: configure
@@ -25,33 +22,6 @@
     - ansible_distribution == item.distro
     - ansible_distribution_major_version == item.version | string
   with_items: "{{ prometheus_valid_distros }}"
-  tags: configure
-
-- name: Preflight > check blackbox interface on nodes (data)
-  set_fact:
-    prometheus_checks: "{{ prometheus_checks | combine({'blackbox_iface_node_data': false}) }}"
-  when:
-    - prometheus_blackbox_enabled
-    - inventory_hostname in prometheus_monitored_hosts
-    - ('ansible_' + prometheus_blackbox_node_data_iface) is not defined
-  tags: configure
-
-- name: Preflight > check blackbox interface on nodes (admin)
-  set_fact:
-    prometheus_checks: "{{ prometheus_checks | combine({'blackbox_iface_node_admin': false}) }}"
-  when:
-    - prometheus_blackbox_enabled
-    - inventory_hostname in prometheus_monitored_hosts
-    - ('ansible_' + prometheus_blackbox_node_admin_iface) is not defined
-  tags: configure
-
-- name: Preflight > check blackbox interface on admin
-  set_fact:
-    prometheus_checks: "{{ prometheus_checks | combine({'blackbox_iface_admin': false}) }}"
-  when:
-    - prometheus_blackbox_enabled
-    - inventory_hostname in prometheus_admin_hosts
-    - ('ansible_' + prometheus_blackbox_admin_iface) is not defined
   tags: configure
 
 - name: Perform a stat on the inventory file


### PR DESCRIPTION
 ##### SUMMARY

When using either openio_bind_mgmt_iface or openio_bind_mgmt_address,
the checks would use incorrect networks, most of the times defaulting
improperly to openio_bind_address. This fixes this behavior, and adds
additional CI checks to ensure proper behavior in all cases.

 ##### IMPACT

This removes `prometheus_blackbox_*_iface` defaults (which were already
wrapping openio_bind_mgmt interface, and not used directly).