### PR TITLE
BUGFIX/MINOR(prometheus): Fix interface for blackbox check

### DIFF
--- a/templates/blackbox.yml.j2
+++ b/templates/blackbox.yml.j2
@@ -36,7 +36,7 @@
     module: blackbox
     host: "{{ hostname }}"
   targets:
-    - {{ tmp_cached_node_data_ip[hostname] }}=>{{ tmp_cached_node_data_ip[hostname] }}:{{ prometheus_blackbox_port }}
+    - {{ tmp_cached_node_admin_ip[hostname] }}=>{{ tmp_cached_node_admin_ip[hostname] }}:{{ prometheus_blackbox_port }}
 {% endfor %}
 
 {% for svc in prometheus_oioping_services %}


### PR DESCRIPTION
 ##### SUMMARY

The prometheus check that verifies that blackbox itself is up was using
the (wrong) data interface. This fixes this behavior

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION