### PR TITLE
CHANGE(prometheus): update blackbox label replacement rules

### DIFF
--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -92,9 +92,6 @@ scrape_configs:
     # Module replacements
     - source_labels: [module]
       target_label: __param_module
-    # Job replacements
-    - source_labels: [module]
-      target_label: job
 
     # in: 10.240.0.23=>10.240.0.24:6014
     # out: 10.240.0.24:6014


### PR DESCRIPTION
 ##### SUMMARY
Remove the label replacement rule overriding `job` with `module`.

 ##### IMPACT
@vdombrovski 