### PR TITLE
FEATURE(prometheus): Add healtchecks for keystone and galera

### DIFF
--- a/files/alert_rules.yml
+++ b/files/alert_rules.yml
@@ -176,6 +176,26 @@ groups:
             If the issue persists, please contact the OpenIO support.
             The alert will be resolved once there is at least one account instance running and scored on the cluster.
 
+      - alert: IAM Backend malfunction
+        expr: count(probe_success{service_type=~'galera|keystone'} == 0) > 0
+        for: 30s
+        labels:
+          severity: medium
+        annotations:
+          summary: IAM Backend malfunction
+          description: >-
+            The identity management service is malfunctioning. This could eventually result in permission denied errors
+            on the gateway.
+          solutions: >-
+            Start by checking the status of the galera mysql service by running <code>systemctl status mariadb</code>
+            Individual services can be restarted using <code>galera_recovery</code> and <code>galera_new_cluster</code>
+            commands.
+            If the backend is working, proceed to checking keystone logs and the service by issuing
+            <code>gridinit_cmd status @keystone</code>.
+            When no errors can be found, please contact the OpenIO support. If a package update, or a node configuration
+            change has been made prior to this alert, please include its details in the ticket.
+            The alert will be resolved once all instances of the IAM service are responding correctly.
+
       - alert: MetricCollectionFailure
         expr: up{job=~'blackbox|netdata'} == 0
         for: 60s

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -106,7 +106,7 @@ scrape_configs:
     # in: beanstalkd;10.240.0.23=>10.240.0.24:6014
     # out: 10.240.0.24:6014
     - source_labels: [module, __address__]
-      regex: (?:beanstalkd|icmpcheck|redis|redissentinel|tcpcheck|zookeeper|oioping|blackbox);[^=]+=>(.+)
+      regex: (?:beanstalkd|icmpcheck|redis|redissentinel|tcpcheck|zookeeper|oioping|blackbox|keystone);[^=]+=>(.+)
       target_label: __param_target
 
     # in: rdir;10.240.0.23=>10.240.0.24:6301

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -39,10 +39,12 @@ prometheus_monitored_services:
   - redissentinel
   - rdir
   - oioswift
+  - keystone
 
 prometheus_tcpcheck_services:
   - oioproxy
   - beanstalkd
+  - galera
 
 prometheus_oioping_services:
   - meta0


### PR DESCRIPTION
 ##### SUMMARY

This adds additional checks for galera and keystone, aswell as a new
alert (IAM backend malfunction), indicating issues with the identity
management service.

Requires: https://github.com/open-io/ansible-role-openio-blackbox/pull/6

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION