### PR TITLE
BUGFIX/MAJOR(prometheus): Fix Unreachable Node alert definition

### DIFF
--- a/files/alert_rules.yml
+++ b/files/alert_rules.yml
@@ -3,7 +3,7 @@ groups:
   - name: default
     rules:
       - alert: UnreachableNode
-        expr: probe_success{job='icmpcheck'} == 0
+        expr: probe_success{module='icmpcheck'} == 0
         for: 5m
         labels:
           severity: medium


### PR DESCRIPTION
 ##### SUMMARY

The Unreachable Node definition's been broken
since the removal of the `job` label
for the `blackbox` job.