### PR TITLE
BUGFIX/MEDIUM(prometheus): Ensure proper variable name in defaults

### DIFF
--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -1,44 +1,9 @@
 ---
-- name: Install requirements
-  apt:
-    name: apt-transport-https
-    state: present
-  tags: install
-
-- name: Add repository
-  apt_repository:
-    repo: deb https://packagecloud.io/prometheus-deb/release/ubuntu/ xenial main
-    state: present
-  when:
-    - ansible_distribution_release == 'xenial'
-  tags: install
-
-- name: Add Key
-  apt_key:
-    url: https://packagecloud.io/prometheus-deb/release/gpgkey
-    state: present
-  when: ansible_distribution_release == 'xenial'
-  tags: install
-
-- name: Install
-  apt:
-    # TODO: improve version handling
-    name: "prometheus={{ prometheus_version }}-1"
-    allow_unauthenticated: true
-  when: ansible_distribution_release == 'xenial'
-  register: install_packages_xenial
-  until: install_packages_xenial is success
-  retries: 5
-  delay: 2
-  ignore_errors: "{{ ansible_check_mode }}"
-  tags: install
-
 - name: Install
   apt:
     name: prometheus
-  when: ansible_distribution_release == 'bionic'
-  register: install_packages_bionic
-  until: install_packages_bionic is success
+  register: install_packages
+  until: install_packages is success
   retries: 5
   delay: 2
   ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: "Include {{ ansible_distribution }} variables"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+  tags:
+    - install
+    - configure
 
 - name: "Prometheus: checks"
   include_tasks: preflight.yml

--- a/templates/prometheus_opts.j2
+++ b/templates/prometheus_opts.j2
@@ -1,1 +1,1 @@
-PROMETHEUS_OPTS='{% for key, value in prometheus_run_opts.items() -%}--{{key}}{{ '=' if value else '' }}{{ value if value else '' }} {% endfor %}'
+{{ prometheus_defaults_var_name }}='{% for key, value in prometheus_run_opts.items() -%}--{{key}}{{ '=' if value else '' }}{{ value if value else '' }} {% endfor %}'

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,0 +1,3 @@
+---
+prometheus_defaults_var_name: PROMETHEUS_OPTS
+...

--- a/vars/Ubuntu-bionic.yml
+++ b/vars/Ubuntu-bionic.yml
@@ -1,0 +1,3 @@
+---
+prometheus_defaults_var_name: ARGS
+...

--- a/vars/Ubuntu-xenial.yml
+++ b/vars/Ubuntu-xenial.yml
@@ -1,0 +1,3 @@
+---
+prometheus_defaults_var_name: PROMETHEUS_OPTS
+...


### PR DESCRIPTION
 ##### SUMMARY

On Ubuntu prometheus package provides a systemd unit that runs
prometheus with the $ARGS variable; however this variable was named
$PROMETHEUS_OPTS on all distros, causing Prometheus to start with
default options instead of the provided ones. This ensures that the
right variable name is used on each distro.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION