### PR TITLE
BUGFIX/MEDIUM(prometheus): Ensure proper variable name in defaults (19.10)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: "Include {{ ansible_distribution }} variables"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+  tags:
+    - install
+    - configure
 
 - name: "Prometheus: checks"
   include_tasks: preflight.yml

--- a/templates/prometheus_opts.j2
+++ b/templates/prometheus_opts.j2
@@ -1,1 +1,1 @@
-PROMETHEUS_OPTS='{% for key, value in prometheus_run_opts.items() -%}--{{key}}{{ '=' if value else '' }}{{ value if value else '' }} {% endfor %}'
+{{ prometheus_defaults_var_name }}='{% for key, value in prometheus_run_opts.items() -%}--{{key}}{{ '=' if value else '' }}{{ value if value else '' }} {% endfor %}'

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,0 +1,3 @@
+---
+prometheus_defaults_var_name: PROMETHEUS_OPTS
+...

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,3 @@
+---
+prometheus_defaults_var_name: ARGS
+...


### PR DESCRIPTION
 ##### SUMMARY

On Ubuntu prometheus package provides a systemd unit that runs
prometheus with the $ARGS variable; however this variable was named
$PROMETHEUS_OPTS on all distros, causing Prometheus to start with
default options instead of the provided ones. This ensures that the
right variable name is used on each distro.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION