### PR TITLE
CHANGE(prometheus): decrease netdata's tags scrape interval

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,7 @@ prometheus_monitored_hosts: "{{ groups['fronts'] | d([]) + groups['backs'] | d([
 
 # Collection: netdata
 prometheus_netdata_interval: 10s
-prometheus_netdata_tags_interval: 6h
+prometheus_netdata_tags_interval: 5m
 prometheus_netdata_port: 19999
 prometheus_netdata_group: netdata
 prometheus_netdata_bind_interface: "{{ openio_bind_mgmt_interface | d(ansible_default_ipv4.alias) }}"


### PR DESCRIPTION
 ##### SUMMARY
Change netdata's tags scrape interval from 6h to 5m.
An interval of 6h was set to save memory for what is mainly
static, but it caused the UI to be somewhat buggy for the first
few hours after deployment.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION