### PR TITLE
BUGFIX/MINOR(prometheus): Fix fetch/load inventories when running in --check

### DIFF
--- a/tasks/healthchecks.yml
+++ b/tasks/healthchecks.yml
@@ -100,6 +100,7 @@ hostvars[inventory_hostname]['openio_bind_address']) }}"
   changed_when: false
   tags: configure
   become: false
+  check_mode: false
 
 - name: "Fetch inventories"
   fetch:


### PR DESCRIPTION
 ##### SUMMARY

- As an OpenIO administrator,
  When I run a "dry run" deployment  (e.g. adding the option `--check` to get a list of what will be done for the deployment)
  Then I does not want any error and a valid report
- This bugfix forces the task "Create temporary inventory directory" to be run even on `--check` mode, so the registered variable is always available.

 ##### IMPACT

- N.A.

 ##### ADDITIONAL INFORMATION

- Please note that the task "Fetch inventories" is now changed is Ansible detects a change, to help the dry run report to be more precise.