### PR TITLE
BUGFIX/MAJOR(prometheus): Fix the alerts

### DIFF
--- a/templates/rules/openio.alerts.yml.j2
+++ b/templates/rules/openio.alerts.yml.j2
@@ -227,21 +227,26 @@ groups:
             The alert will be resolved once there is at least one account instance running and scored on the cluster.
 
       - alert: IAMMalfunction
-        expr: count(openio_probe_success{service_type=~'galera|keystone'} == 0) > 0
+        expr: count(openio_probe_success{service_type=~'galera|keystone'} == 0) by (service, service_type, target) > 0
         for: 30s
         labels:
           severity: medium
+          host: "{{ $labels.target }}"
         annotations:
           summary: IAM Backend malfunction
           description: >-
-            The identity management service is malfunctioning. This could eventually result in permission denied errors
-            on the gateway.
+            The service '{{ $labels.service }}' is not running on server '{{ $labels.target }}'.
+            The identity management service is thus malfunctioning and this could eventually result
+            in permission denied errors on the gateway.
           solutions: >-
-            Start by checking the status of the galera mysql service by running <code>systemctl status mariadb</code>
+            {{ if eq $labels.service_type "galera" }}
+            Check the status of the galera mysql service by running <code>systemctl status mariadb</code>
             Individual services can be restarted using <code>galera_recovery</code> and <code>galera_new_cluster</code>
             commands.
-            If the backend is working, proceed to checking keystone logs and the service by issuing
-            <code>gridinit_cmd status @keystone</code>.
+            {{ end }}
+            {{ if eq $labels.service_type "keystone" }}
+            Proceed to checking keystone logs and the service by issuing <code>gridinit_cmd status @keystone</code>.
+            {{ end }}
             When no errors can be found, please contact the OpenIO support. If a package update, or a node configuration
             change has been made prior to this alert, please include its details in the ticket.
             The alert will be resolved once all instances of the IAM service are responding correctly.

--- a/templates/rules/openio.alerts.yml.j2
+++ b/templates/rules/openio.alerts.yml.j2
@@ -8,7 +8,7 @@ groups:
       # for now
       #
       - alert: UnreachableNode
-        expr: openio_probe_success{service_type='oio-exporter'} == 0
+        expr: sum(up) by (host) == 0
         for: 5m
         labels:
           severity: medium
@@ -64,7 +64,7 @@ groups:
             The alert will be resolved once the disk space is freed below 90% use.
 
       - alert: ServerErrors
-        expr: openio_log_response_code_sum{code=~"5.*"} > 0
+        expr: sum(openio_log_requests_sum{code=~"5.*"}) by (host, service) > 0
         for: 10m
         labels:
           severity: medium
@@ -94,17 +94,18 @@ groups:
             The alert will be resolved once there are no more buried events on the node.
 
       - alert: MetaDown
-        expr: openio_probe_success{service_type=~'meta[012]'} == 0
+        expr: sum(openio_probe_success{service_type=~'meta[012]'}) by (target, service) == 0
         for: 30s
         labels:
           severity: medium
+          host: "{{ $labels.target }}"
         annotations:
           summary: Metadata service down
           description: >-
-            The service '{{ $labels.service }}' on server '{{ $labels.host }}' doesn't respond to healthchecks.
+            The service '{{ $labels.service }}' on server '{{ $labels.target }}' doesn't respond to healthchecks.
           solutions: >-
             Collect status by running <code>gridinit_cmd status @{{$labels.service}}</code>
-            on the node {{$labels.host}}.
+            on the node {{$labels.target}}.
             If the service is down, try repairing it <code>gridinit_cmd repair</code>.
             If the service is still down, check for I/O errors and other causes preventing the service from starting.
             Also look into the logs located in <code>/var/log/oio/sds/</code> for that particular instance.
@@ -113,20 +114,21 @@ groups:
             to <code>oiotool ping IP:PORT</code> command.
 
       - alert: RawxDown
-        expr: openio_probe_success{service_type='rawx'} == 0
+        expr: sum(openio_probe_success{service_type='rawx'}) by (target, service) == 0
         for: 30s
         labels:
           severity: low
+          host: "{{ $labels.target }}"
         annotations:
           summary: RAWX service down
           description: >-
-            The service '{{ $labels.service }}' on server '{{ $labels.host }}' doesn't respond to healthchecks.
+            The service '{{ $labels.service }}' on server '{{ $labels.target }}' doesn't respond to healthchecks.
             This could indicate underlying data disk failure, which needs to be replaced
           solutions: >-
             Start by fetching the status of all services on the cluster
             <code>openio cluster list rawx | grep ' False '</code>.
             Check the associated volumes for I/O errors. Replace the disks if I/O errors have been detected,
-            then try repairing by using <code>gridinit_cmd repair @rawx</code> on node '{{ $labels.host }}'.
+            then try repairing by using <code>gridinit_cmd repair @rawx</code> on node '{{ $labels.target }}'.
             Unlock the score of the service <code>openio cluster unlock rawx '{{ $labels.service }}'</code>,
             then follow the procedure to start rebuilding data on the volume.
             If you are not able to determine the issue, please contact the OpenIO support.
@@ -134,18 +136,19 @@ groups:
             is marked as up in `openio cluster list` and is scored.
 
       - alert: RedisDown
-        expr: openio_probe_success{service_type=~'redis|redissentinel'} == 0
+        expr: sum(openio_probe_success{service_type=~'redis|redissentinel'}) by (target, service) == 0
         for: 60s
         labels:
           severity: medium
+          host: "{{ $labels.target }}"
         annotations:
           summary: Redis backend malfunction
           description: >-
-            The service '{{ $labels.service }}' on server '{{ $labels.host }}' doesn't respond to healthchecks.
+            The service '{{ $labels.service }}' on server '{{ $labels.target }}' doesn't respond to healthchecks.
             This can cause server errors and must be investigated.
           solutions: >-
             Start by checking that the instance is up by running <code>gridinit_cmd status</code>
-            on '{{ $labels.host }}'.
+            on '{{ $labels.target }}'.
             If the instance is broken, consult the logs of the service located in /var/log/oio/sds/.
             Check that the underlying storage device is functional.
             If the problem persists, please contact the OpenIO support.
@@ -193,14 +196,15 @@ groups:
 #            on them to prevent further split-brain damage. Contact OpenIO support for further steps.
 
       - alert: ServiceDown
-        expr: openio_probe_success{service_type!~'meta\\d|redis.*|rawx|'} == 0
+        expr: sum(openio_probe_success{service_type!~'meta\\d|redis.*|rawx|'}) by (target, service_type, service) == 0
         for: 60s
         labels:
           severity: medium
+          host: "{{ $labels.target }}"
         annotations:
           summary: Service {{ $labels.service_type }} down
           description: >-
-            The service '{{ $labels.service }}' on server '{{ $labels.host }}' doesn't respond to healthchecks.
+            The service '{{ $labels.service }}' on server '{{ $labels.target }}' doesn't respond to healthchecks.
 
       - alert: AccountMalfunction
         expr: (count(openio_probe_success{service_type="account"} == 1) == 0)
@@ -247,20 +251,20 @@ groups:
         for: 60s
         labels:
           severity: medium
-          service: "{{ $labels.module }}"
+          service: "{{ $labels.job }}"
         annotations:
           summary: Metric collection failure
           description: >-
-            The metric collection service '{{ $labels.module }}' on server '{{ $labels.host }}' is down.
+            The metric collection service '{{ $labels.job }}' on server '{{ $labels.host }}' is down.
             This prevents monitoring from working properly and must be resolved.
           solutions: >-
             Check the state of the service by running
-            <code>systemctl status {{ if eq $labels.module "blackbox" }}blackbox_exporter{{ else }}netdata{{ end }}.
+            <code>gridinit_cmd status @{{ if eq $labels.job "oio-exporter" }}oio-exporter{{ else }}oio-netdata{{ end }}.
             If the service isn't started, start and enable it.
             If the service fails to start, contact the OpenIO support.
             Check that the service is reachable, if not, make sure ports 19999 and 9115 are open.
             You can test the availability by doing a HTTP GET request on the IP/port of the service.
-            The alert will be resolved when '{{ $labels.module }}' is up and running
+            The alert will be resolved when '{{ $labels.job }}' is up and running
             and can be contacted by the admin machine.
 
       - alert: MultipleVersions
@@ -299,7 +303,7 @@ groups:
             data to replicate (the fresh data that has been pushed to the cluster).
 
       - alert: Eventlet package version
-        expr: count(openio_version{software=~"^eventlet.*",version=~"0\\.(\\d|1\\d|2[01234])\\.\\d+-\\d+"}) > 0
+        expr: count(openio_version{software=~"^eventlet.*",version=~"0\\.(\\d|1\\d|2[01234])\\.\\d+-\\d+"}) by (software) > 0
         for: 60s
         labels:
           code: ERROR_EVENTLET_VERSION

--- a/templates/rules/openio.alerts.yml.j2
+++ b/templates/rules/openio.alerts.yml.j2
@@ -11,6 +11,7 @@ groups:
         expr: sum(up) by (host) == 0
         for: 5m
         labels:
+          code: ERROR_UNREACHABLE_NODE
           severity: medium
         annotations:
           summary: Unreachable node
@@ -30,6 +31,7 @@ groups:
           sum(netdata_system_ram_MiB_average{dimension='used'}) by (host)
         for: 5m
         labels:
+          code: ERROR_LOW_MEMORY
           severity: low
         annotations:
           summary: Low on memory
@@ -48,6 +50,7 @@ groups:
           sum(netdata_disk_space_GiB_average{dimension='used'}) by (host, family)
         for: 10s
         labels:
+          code: ERROR_LOW_DISK_SPACE
           severity: low
           volume: "{{ $labels.family }}"
         annotations:
@@ -67,6 +70,7 @@ groups:
         expr: sum(openio_log_requests_sum{code=~"5.*"}) by (host, service) > 0
         for: 10m
         labels:
+          code: ERROR_SERVER_ERRORS
           severity: medium
         annotations:
           summary: Server errors
@@ -82,6 +86,7 @@ groups:
         expr: sum(openio_beanstalkd_jobs{status="buried", tube="*"}) by (host) > 0
         for: 10m
         labels:
+          code: ERROR_BURIED_EVENTS
           severity: low
         annotations:
           summary: Background jobs failures
@@ -97,6 +102,7 @@ groups:
         expr: sum(openio_probe_success{service_type=~'meta[012]'}) by (target, service) == 0
         for: 30s
         labels:
+          code: ERROR_META_DOWN
           severity: medium
           host: "{{ $labels.target }}"
         annotations:
@@ -117,6 +123,7 @@ groups:
         expr: sum(openio_probe_success{service_type='rawx'}) by (target, service) == 0
         for: 30s
         labels:
+          code: ERROR_RAWX_DOWN
           severity: low
           host: "{{ $labels.target }}"
         annotations:
@@ -139,6 +146,7 @@ groups:
         expr: sum(openio_probe_success{service_type=~'redis|redissentinel'}) by (target, service) == 0
         for: 60s
         labels:
+          code: ERROR_REDIS_DOWN
           severity: medium
           host: "{{ $labels.target }}"
         annotations:
@@ -159,6 +167,7 @@ groups:
           by (cluster) < 1
         for: 30s
         labels:
+          code: ERROR_REDIS_NO_MASTER
           severity: medium
           cluster: "{{ $labels.cluster }}"
         annotations:
@@ -199,6 +208,7 @@ groups:
         expr: sum(openio_probe_success{service_type!~'meta\\d|redis.*|rawx|'}) by (target, service_type, service) == 0
         for: 60s
         labels:
+          code: ERROR_SERVICE_DOWN
           severity: medium
           host: "{{ $labels.target }}"
         annotations:
@@ -211,6 +221,7 @@ groups:
               or sum(openio_score{service_type="account"}) == 0
         for: 30s
         labels:
+          code: ERROR_ACCOUNT_MALFUNCTION
           severity: medium
         annotations:
           summary: Account service malfunction
@@ -230,6 +241,7 @@ groups:
         expr: count(openio_probe_success{service_type=~'galera|keystone'} == 0) by (service, service_type, target) > 0
         for: 30s
         labels:
+          code: ERROR_IAM_MALFUNCTION
           severity: medium
           host: "{{ $labels.target }}"
         annotations:
@@ -255,6 +267,7 @@ groups:
         expr: up{job=~'oio-exporter|netdata'} == 0
         for: 60s
         labels:
+          code: ERROR_METRIC_COLLECTION_FAILURE
           severity: medium
           service: "{{ $labels.job }}"
         annotations:
@@ -290,6 +303,7 @@ groups:
         expr: count(openio_beanstalkd_jobs{status="ready", tube="oio-repli"}) by (host) > 0
         for: 10m
         labels:
+          code: ERROR_REPLI_EVENTS
           severity: low
         annotations:
           summary: Replicator is not working properly
@@ -307,7 +321,7 @@ groups:
             Note: the speed of the replication highly depends on the network in between and the amount of
             data to replicate (the fresh data that has been pushed to the cluster).
 
-      - alert: Eventlet package version
+      - alert: EventletVersion
         expr: count(openio_version{software=~"^eventlet.*",version=~"0\\.(\\d|1\\d|2[01234])\\.\\d+-\\d+"}) by (software) > 0
         for: 60s
         labels:


### PR DESCRIPTION
 ##### SUMMARY
Several alerts were broken following the move to 'oio-exporter', for diverse reasons:
- Failure to aggregate giving multiple alerts for the same problem
- Usage of the wrong label when using healthchecks: "host" is the host of oio-exporter, not the healthcheck target
- Usage of unexisting metrics
- Usage of unexisting labels

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION