### PR TITLE
BUGFIX/MINOR(prometheus): Check mode on `prometheus_node_admin_ip`

### DIFF
--- a/tasks/healthchecks.yml
+++ b/tasks/healthchecks.yml
@@ -56,6 +56,14 @@ hostvars[inventory_hostname]['openio_bind_address']) }}"
     - openio_bind_mgmt_interface is not defined
   tags: configure
 
+- name: "Register admin IP of monitored node (check mode)"
+  set_fact:
+    prometheus_node_admin_ip: "ip_admin_check_mode"
+  when:
+    - inventory_hostname in prometheus_monitored_hosts
+    - ansible_check_mode
+  tags: configure
+
 - name: Cache hostnames
   set_fact:
     tmp_cached_hostnames: "{{ tmp_cached_hostnames | combine({item: hostvars[item]['ansible_nodename']}) }}"


### PR DESCRIPTION
 ##### SUMMARY

Without inventories fetched, the `prometheus_node_admin_ip` is not defined.

This define a placeholder to avoid failure.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION

```
TASK [prometheus : Cache host data] ************************************************************************************************************************************************************************
Thursday 25 June 2020  13:14:38 +0000 (0:00:00.198)       0:26:09.093 *********
ok: [node-admin] => (item={'value': u'8ed201b9ab19', 'key': u'node3'})
fatal: [node-admin]: FAILED! =>
  msg: |-
    The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'prometheus_node_admin_ip'
    The error appears to be in '/home/centos/git/customer-skeleton/deployment/sds/roles/prometheus/tasks/healthchecks.yml': line 74, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
    The offending line appears to be:
    - name: Cache host data
      ^ here
```

with this PR
```
TASK [prometheus : Generate healthchecks] ******************************************************************************************************************************************************************
Thursday 25 June 2020  13:30:51 +0000 (0:00:00.151)       0:00:14.881 *********
skipping: [node3]
skipping: [node2]
skipping: [node5]
skipping: [node7]
skipping: [node6]
skipping: [node4]
--- before
+++ after: /home/centos/.ansible/tmp/ansible-local-158585KKRzK/tmpwhVd1a/blackbox.yml.j2
@@ -0,0 +1,51 @@
+# OpenIO managed
+
+- labels:
+    module: icmpcheck
+    host: "203e8b8f5aa2"
+  targets:
+    - 172.25.10.51=>ip_admin_check_mode
+- labels:
+    module: icmpcheck
+    host: "20ef719148ba"
+  targets:
+    - 172.25.10.51=>ip_admin_check_mode
+- labels:
+    module: icmpcheck
+    host: "0d96f9b3eddc"
+  targets:
+    - 172.25.10.51=>ip_admin_check_mode
+- labels:
+    module: icmpcheck
+    host: "8ed201b9ab19"
+  targets:
+    - 172.25.10.51=>ip_admin_check_mode
+- labels:
+    module: icmpcheck
+    host: "2001c2739a09"
+  targets:
+    - 172.25.10.51=>ip_admin_check_mode
+- labels:
+    module: icmpcheck
+    host: "8e57ce6ffe5d"
+  targets:
+    - 172.25.10.51=>ip_admin_check_mode
+
+
+- labels:
+    module: blackbox
+    host: "8e322e60d4f8"
+  targets:
+    - 172.25.10.51=>172.25.10.51:9115
+
+
+
+
+
+- labels:
+    module: oiofs
+    host: "0d96f9b3eddc"
+    service_type: oiofs
+    service: oiofs-JENKINS-MY_ACCOUNT1-MY_CONTAINER1
+  targets:
+    - ip_admin_check_mode=>127.0.0.1:6989

changed: [node-admin]
```